### PR TITLE
Here is a FIX for a segfault in usbmuxd when connecting an IPHONE4S...

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -476,6 +476,11 @@ static int client_command(struct mux_client *client, struct usbmuxd_header *hdr)
 			} else {
 				char *message = NULL;
 				plist_t node = plist_dict_get_item(dict, "MessageType");
+				if (!node) {
+					usbmuxd_log(LL_ERROR, "plist_dict_get_item failed!");
+					plist_free(dict);
+					return -1;
+				}
 				plist_get_string_val(node, &message);
 				if (!message) {
 					usbmuxd_log(LL_ERROR, "Could not extract MessageType from plist!");


### PR DESCRIPTION
....

Symptom:
usbmuxd[3579]: segfault at 0 ip 00007fc99315b0f1 sp 00007fffbfa84ce8 error 4 in libc-2.17.so[7fc992ff1000+1bd000]
