### PR TITLE
FreeBSD 11 supports ppoll, so only use shim when necessary

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -159,7 +159,7 @@ static void set_signal_handlers(void)
 	sigaction(SIGUSR2, &sa, NULL);
 }
 
-#if defined(__FreeBSD__) || defined(__APPLE__)
+#if (defined(__FreeBSD__) && __FreeBSD__ < 11) || defined(__APPLE__)
 static int ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *timeout, const sigset_t *sigmask)
 {
 	int ready;


### PR DESCRIPTION
FreeBSD 11.0 (currently in beta) adds the ```ppoll``` call to the standard library, causing the build to break:

```
  CC       usbmuxd-main.o
main.c:153:12: error: static declaration of 'ppoll' follows non-static declaration
static int ppoll(struct pollfd *fds, nfds_t nfds, const struct timespec *timeout, const sigset_t *sigmask)
           ^
/usr/include/poll.h:114:5: note: previous declaration is here
int     ppoll(struct pollfd _pfd[], nfds_t _nfds,
        ^
1 error generated.
*** [usbmuxd-main.o] Error code 1
```

This fixes that build error and allows the software to work correctly on FreeBSD.