### PR TITLE
Memory fixes

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -373,6 +373,7 @@ static int send_system_buid(struct mux_client *client, uint32_t tag)
 
 	plist_t dict = plist_new_dict();
 	plist_dict_set_item(dict, "BUID", plist_new_string(buid));
+	free(buid);
 	res = send_plist_pkt(client, tag, dict);
 	plist_free(dict);
 	return res;

--- a/src/conf.c
+++ b/src/conf.c
@@ -290,7 +290,6 @@ static int internal_get_value(const char* config_file, const char *key, plist_t 
 		plist_t n = plist_dict_get_item(config, key);
 		if (n) {
 			*value = plist_copy(n);
-			plist_free(n);
 			n = NULL;
 		}
 	}


### PR DESCRIPTION
* `plist_new_string` copies the string argument, so the original must be freed. 
* `plist_dict_get_item` returns a reference without copying, so the returned value should not be freed.