### PR TITLE
Fix --with-systemd argument to configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ fi
 AC_ARG_WITH([systemd],
             [AS_HELP_STRING([--without-systemd],
             [do not build with systemd support @<:@default=yes@:>@])],
-            [with_systemd=no],
+            [],
             [with_systemd=yes])
 
 AC_ARG_WITH([systemdsystemunitdir],


### PR DESCRIPTION
Otherwise, specifying ''--with-systemd'' will actually lead to systemd support being disabled.
Got that from https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/External-Software.html (last example).