### PR TITLE
Support usbmuxd on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,6 @@ py-compile
 stamp-h1
 src/.libs
 src/usbmuxd
+src/usbmuxd.exe
 udev/39-usbmuxd.rules
 systemd/usbmuxd.service

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,6 +3,7 @@ Bastien Nocera
 Cerrato Renaud
 Christophe Fergeau
 David Sansome
+Frederik Carlier
 Hector Martin
 Jacob Myers
 John Maguire

--- a/src/client.c
+++ b/src/client.c
@@ -23,6 +23,10 @@
 #include <config.h>
 #endif
 
+#ifdef _MSC_VER
+#include "config_msc.h"
+#endif
+
 #define _GNU_SOURCE 1
 
 #ifdef WIN32

--- a/src/client.h
+++ b/src/client.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2009 Hector Martin <hector@marcansoft.com>
  * Copyright (C) 2009 Nikias Bassen <nikias@gmx.li>
+ * Copyright (C) 2014 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/conf.c
+++ b/src/conf.c
@@ -21,6 +21,7 @@
 #include <config.h>
 #endif
 
+#include <Windows.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/conf.c
+++ b/src/conf.c
@@ -22,6 +22,10 @@
 #endif
 
 #include <Windows.h>
+#ifdef _MSC_VER
+#include "config_msc.h"
+#endif
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -32,12 +36,15 @@
 #endif
 
 #include <dirent.h>
+#ifndef _MSC_VER
 #include <libgen.h>
+#endif
 #include <sys/stat.h>
 #include <errno.h>
 
 #ifdef WIN32
 #include <shlobj.h>
+#include <direct.h>
 #endif
 
 #include "conf.h"

--- a/src/conf.c
+++ b/src/conf.c
@@ -2,6 +2,7 @@
  * conf.c
  *
  * Copyright (C) 2013 Nikias Bassen <nikias@gmx.li>
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/config_msc.c
+++ b/src/config_msc.c
@@ -1,0 +1,8 @@
+#include "config_msc.h"
+
+char *dirname(char const *file)
+{
+	char* dir[256];
+	_splitpath(file, 0, dir, 0, 0);
+	return dir;
+}

--- a/src/config_msc.h
+++ b/src/config_msc.h
@@ -1,0 +1,4 @@
+#pragma once
+#define PACKAGE_NAME "usbmuxd"
+#define PACKAGE_STRING "usbmuxd 1.1.1"
+#define PACKAGE_VERSION "1.1.1"

--- a/src/config_msc.h
+++ b/src/config_msc.h
@@ -2,3 +2,7 @@
 #define PACKAGE_NAME "usbmuxd"
 #define PACKAGE_STRING "usbmuxd 1.1.1"
 #define PACKAGE_VERSION "1.1.1"
+#define HAVE_STRUCT_TIMESPEC 1
+#include <stdlib.h>
+
+char *dirname(char const *file);

--- a/src/device.c
+++ b/src/device.c
@@ -24,9 +24,17 @@
 #include <config.h>
 #endif
 
-#include <sys/time.h>
+#ifdef WIN32
+#include <ws2tcpip.h>
+#include <winsock2.h>
+#include "winsock2-ext.h"
+#include "tcp.h"
+#else
 #include <netinet/in.h>
 #include <netinet/tcp.h>
+#include <sys/time.h>
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdint.h>

--- a/src/device.c
+++ b/src/device.c
@@ -24,6 +24,10 @@
 #include <config.h>
 #endif
 
+#ifdef _MSC_VER
+#include "config_msc.h"
+#endif
+
 #ifdef WIN32
 #include <ws2tcpip.h>
 #include <winsock2.h>

--- a/src/device.c
+++ b/src/device.c
@@ -949,6 +949,7 @@ int device_get_list(int include_hidden, struct device_info **devices)
 	return count;
 }
 
+#ifndef WIN32
 int device_get_timeout(void)
 {
 	uint64_t oldest = (uint64_t)-1LL;
@@ -988,6 +989,7 @@ void device_check_timeouts(void)
 	} ENDFOREACH
 	pthread_mutex_unlock(&device_list_mutex);
 }
+#endif
 
 void device_init(void)
 {

--- a/src/device.c
+++ b/src/device.c
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2009 Hector Martin "marcan" <hector@marcansoft.com>
  * Copyright (C) 2014 Mikkel Kamstrup Erlandsen <mikkel.kamstrup@xamarin.com>
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/device.h
+++ b/src/device.h
@@ -46,8 +46,10 @@ void device_set_preflight_cb_data(int device_id, void* data);
 int device_get_count(int include_hidden);
 int device_get_list(int include_hidden, struct device_info **devices);
 
+#ifndef WIN32
 int device_get_timeout(void);
 void device_check_timeouts(void);
+#endif
 
 void device_init(void);
 void device_kill_connections(void);

--- a/src/device.h
+++ b/src/device.h
@@ -2,6 +2,7 @@
  * device.h
  *
  * Copyright (C) 2009 Hector Martin <hector@marcansoft.com>
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/log.c
+++ b/src/log.c
@@ -28,8 +28,12 @@
 #include <string.h>
 #include <stdarg.h>
 #include <time.h>
-#include <time.h>
+#ifdef _MSC_VER
+// Includes a definition for 'timeval'
+#include "winsock2.h"
+#else
 #include <sys/time.h>
+#endif
 
 #ifdef WIN32
 #else

--- a/src/log.h
+++ b/src/log.h
@@ -34,8 +34,11 @@ enum loglevel {
 
 extern unsigned int log_level;
 
+#ifdef WIN32
+#else
 void log_enable_syslog();
 void log_disable_syslog();
+#endif
 
 void usbmuxd_log(enum loglevel level, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
 

--- a/src/log.h
+++ b/src/log.h
@@ -40,6 +40,10 @@ void log_enable_syslog();
 void log_disable_syslog();
 #endif
 
-void usbmuxd_log(enum loglevel level, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+void usbmuxd_log(enum loglevel level, const char *fmt, ...) 
+#ifndef _MSC_VER
+__attribute__ ((format (printf, 2, 3)))
+#endif
+;
 
 #endif

--- a/src/log.h
+++ b/src/log.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2009 Hector Martin "marcan" <hector@marcansoft.com>
  * Copyright (C) 2009 Nikias Bassen <nikias@gmx.li>
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/main.c
+++ b/src/main.c
@@ -62,6 +62,7 @@
 #include "conf.h"
 #include <pthread.h>
 #include <signal.h>
+#include "usbmuxd-proto.h"
 
 static const char *socket_path = "/var/run/usbmuxd";
 static const char *lockfile = "/var/run/usbmuxd.pid";
@@ -141,7 +142,7 @@ static socket_handle create_socket(void) {
 	}
 #endif
 
-	bzero(&bind_addr, sizeof(bind_addr));
+	memset(&bind_addr, 0, sizeof(bind_addr));
 
 #ifdef WIN32  
 	bind_addr.sin_family = AF_INET;

--- a/src/preflight.c
+++ b/src/preflight.c
@@ -2,6 +2,7 @@
  * preflight.c
  *
  * Copyright (C) 2013 Nikias Bassen <nikias@gmx.li>
+ * Copyright (C) 2014 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,14 +22,24 @@
 #include <config.h>
 #endif
 
+#ifdef _MSC_VER
+#include "config_msc.h"
+#endif
+
 #include <stdlib.h>
 #include <string.h>
+#ifndef _MSC_VER
 #include <unistd.h>
+#include <sys/time.h>
+#endif
 #include <errno.h>
 
 #include <pthread.h>
 
-#include <sys/time.h>
+
+#ifdef WIN32
+#include <windows.h>
+#endif
 
 #ifdef HAVE_LIBIMOBILEDEVICE
 #include <libimobiledevice/libimobiledevice.h>
@@ -268,7 +279,11 @@ retry:
 		client_device_add(info);
 
 		while (cbdata.np && cbdata.is_device_connected == 1) {
+#ifdef WIN32
+			Sleep(1);
+#else
 			sleep(1);
+#endif
 		}
 		device_set_preflight_cb_data(info->id, NULL);
 

--- a/src/tcp.h
+++ b/src/tcp.h
@@ -1,0 +1,23 @@
+/*
+* TCP header.
+* Per RFC 793, September, 1981.
+*/
+
+typedef	u_long	tcp_seq;
+
+#define	TH_ACK	0x10
+#define	TH_SYN	0x02
+#define	TH_RST	0x04
+
+struct tcphdr {
+	u_short	th_sport;		/* source port */
+	u_short	th_dport;		/* destination port */
+	tcp_seq	th_seq;			/* sequence number */
+	tcp_seq	th_ack;			/* acknowledgement number */
+	u_char	th_x2 : 4,		/* (unused) */
+	th_off : 4;				/* data offset */
+	u_char	th_flags;
+	u_short	th_win;			/* window */
+	u_short	th_sum;			/* checksum */
+	u_short	th_urp;			/* urgent pointer */
+};

--- a/src/usb.c
+++ b/src/usb.c
@@ -574,6 +574,7 @@ uint64_t usb_get_speed(struct usb_device *dev)
 	return dev->speed;
 }
 
+#ifndef WIN32
 void usb_get_fds(struct fdlist *list)
 {
 	const struct libusb_pollfd **usbfds;
@@ -590,6 +591,7 @@ void usb_get_fds(struct fdlist *list)
 	}
 	free(usbfds);
 }
+#endif
 
 void usb_autodiscover(int enable)
 {

--- a/src/usb.c
+++ b/src/usb.c
@@ -5,6 +5,7 @@
  * Copyright (C) 2009 Nikias Bassen <nikias@gmx.li>
  * Copyright (C) 2009 Martin Szulecki <opensuse@sukimashita.com>
  * Copyright (C) 2014 Mikkel Kamstrup Erlandsen <mikkel.kamstrup@xamarin.com>
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/usb.c
+++ b/src/usb.c
@@ -121,7 +121,7 @@ static void reap_dead_devices(void) {
 }
 
 // Callback from write operation
-static void tx_callback(struct libusb_transfer *xfer)
+static void LIBUSB_CALL tx_callback(struct libusb_transfer *xfer)
 {
 	struct usb_device *dev = xfer->user_data;
 	usbmuxd_log(LL_SPEW, "TX callback dev %d-%d len %d -> %d status %d", dev->bus, dev->address, xfer->length, xfer->actual_length, xfer->status);
@@ -193,7 +193,7 @@ int usb_send(struct usb_device *dev, const unsigned char *buf, int length)
 // Callback from read operation
 // Under normal operation this issues a new read transfer request immediately,
 // doing a kind of read-callback loop
-static void rx_callback(struct libusb_transfer *xfer)
+static void LIBUSB_CALL rx_callback(struct libusb_transfer *xfer)
 {
 	struct usb_device *dev = xfer->user_data;
 	usbmuxd_log(LL_SPEW, "RX callback dev %d-%d len %d status %d", dev->bus, dev->address, xfer->actual_length, xfer->status);
@@ -667,7 +667,7 @@ int usb_process_timeout(int msec)
 #ifdef HAVE_LIBUSB_HOTPLUG_API
 static libusb_hotplug_callback_handle usb_hotplug_cb_handle;
 
-static int usb_hotplug_cb(libusb_context *ctx, libusb_device *device, libusb_hotplug_event event, void *user_data)
+static int LIBUSB_CALL usb_hotplug_cb(libusb_context *ctx, libusb_device *device, libusb_hotplug_event event, void *user_data)
 {
 	if (LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED == event) {
 		if (device_hotplug) {

--- a/src/usb.h
+++ b/src/usb.h
@@ -49,7 +49,7 @@
 
 struct usb_device;
 
-int usb_init(void);
+int usb_initialize(void);
 void usb_shutdown(void);
 const char *usb_get_serial(struct usb_device *dev);
 uint32_t usb_get_location(struct usb_device *dev);

--- a/src/usb.h
+++ b/src/usb.h
@@ -55,7 +55,11 @@ const char *usb_get_serial(struct usb_device *dev);
 uint32_t usb_get_location(struct usb_device *dev);
 uint16_t usb_get_pid(struct usb_device *dev);
 uint64_t usb_get_speed(struct usb_device *dev);
+
+#ifndef WIN32
 void usb_get_fds(struct fdlist *list);
+#endif
+
 int usb_get_timeout(void);
 int usb_send(struct usb_device *dev, const unsigned char *buf, int length);
 int usb_discover(void);

--- a/src/usb.h
+++ b/src/usb.h
@@ -4,6 +4,7 @@
  * Copyright (C) 2009 Hector Martin <hector@marcansoft.com>
  * Copyright (C) 2009 Nikias Bassen <nikias@gmx.li>
  * Copyright (C) 2009 Martin Szulecki <opensuse@sukimashita.com>
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/usb_win32.c
+++ b/src/usb_win32.c
@@ -1,0 +1,83 @@
+#ifdef WIN32
+#include "usb_win32.h"
+#include <stdint.h>
+#include <lusb0_usb.h>
+#include "log.h"
+#include "usb.h"
+
+usb_dev_handle *usb_win32_open(const char serial[]);
+
+void usb_win32_init()
+{
+	usb_init();
+
+#if _DEBUG
+	usb_set_debug(255);
+#endif
+
+	usb_find_busses(); /* find all busses */
+	usb_find_devices(); /* find all connected devices */
+}
+
+void usb_win32_set_configuration(const char serial[], uint8_t configuration)
+{
+	usbmuxd_log(LL_INFO, "Setting configuration for device %s using libusb-win32", serial, configuration);
+
+	usb_dev_handle* device = usb_win32_open(serial);
+
+	if (device == NULL) {
+		usbmuxd_log(LL_INFO, "Could not find the device %s using libusb-win32", serial, configuration);
+		return;
+	}
+
+	int res = usb_set_configuration(device, configuration);
+
+	usb_close(device);
+}
+
+usb_dev_handle *usb_win32_open(const char serial[])
+{
+	struct usb_bus *bus;
+	struct usb_device *dev;
+
+	usbmuxd_log(LL_INFO, "Finding device %s using libusb-win32", serial);
+
+	bus = usb_get_busses();
+
+	for (bus; bus; bus = bus->next)
+	{
+		for (dev = bus->devices; dev; dev = dev->next)
+		{
+			if (dev->descriptor.idVendor != VID_APPLE
+				|| dev->descriptor.idProduct < PID_RANGE_LOW
+				|| dev->descriptor.idProduct > PID_RANGE_MAX)
+			{
+				usbmuxd_log(LL_INFO, "Found device %d on bus %d using libusb-win32, but it is not an Apple device. Skipping", dev->devnum, bus->location);
+				continue;
+			}
+
+			usb_dev_handle *handle = usb_open(dev);
+
+			char dev_serial[40];
+			int ret = usb_get_string_simple(handle, dev->descriptor.iSerialNumber, dev_serial, sizeof(dev_serial));
+
+			if(ret < 0) {
+				usbmuxd_log(LL_INFO, "Could not get the UDID for device %d on bus %d using libusb-win32. Skipping", dev->devnum, bus->location);
+				usb_close(dev);
+				continue;
+			}
+
+			if (strcmp(dev_serial, serial) != 0)
+			{
+				usbmuxd_log(LL_INFO, "The not get the UDID for device %d, %s, on bus %d does not match teh requested UDID %s. Skipping", dev->devnum, dev_serial, bus->location, serial);
+				usb_close(dev);
+				continue;
+			}
+
+			return handle;
+		}
+	}
+
+	return NULL;
+}
+#endif

--- a/src/usb_win32.c
+++ b/src/usb_win32.c
@@ -1,3 +1,22 @@
+/*
+ * usb_win32.c
+ *
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 #ifdef WIN32
 #include "usb_win32.h"
 #include <stdint.h>

--- a/src/usb_win32.h
+++ b/src/usb_win32.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#ifdef WIN32
+#include <stdint.h>
+
+void usb_win32_init();
+void usb_win32_set_configuration(const char serial[], uint8_t configuration);
+#endif

--- a/src/usb_win32.h
+++ b/src/usb_win32.h
@@ -1,3 +1,22 @@
+/*
+ * usb_win32.h
+ *
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 #pragma once
 
 #ifdef WIN32

--- a/src/usbmuxd-proto.h
+++ b/src/usbmuxd-proto.h
@@ -32,6 +32,12 @@
 #define USBMUXD_SOCKET_FILE "/var/run/usbmuxd"
 #endif
 
+#ifdef _MSC_VER
+#define PACK( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
+#else
+#define PACK( __Declaration__ ) __Declaration__ __attribute__((__packed__))
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -57,36 +63,41 @@ enum usbmuxd_msgtype {
 	MESSAGE_PLIST = 8,
 };
 
+PACK(
 struct usbmuxd_header {
 	uint32_t length;    // length of message, including header
 	uint32_t version;   // protocol version
 	uint32_t message;   // message type
 	uint32_t tag;       // responses to this query will echo back this tag
-} __attribute__((__packed__));
+});
 
+PACK(
 struct usbmuxd_result_msg {
 	struct usbmuxd_header header;
 	uint32_t result;
-} __attribute__((__packed__));
+});
 
+PACK(
 struct usbmuxd_connect_request {
 	struct usbmuxd_header header;
 	uint32_t device_id;
 	uint16_t port;   // TCP port number
 	uint16_t reserved;   // set to zero
-} __attribute__((__packed__));
+});
 
+PACK(
 struct usbmuxd_listen_request {
 	struct usbmuxd_header header;
-} __attribute__((__packed__));
+});
 
+PACK(
 struct usbmuxd_device_record {
 	uint32_t device_id;
 	uint16_t product_id;
 	char serial_number[256];
 	uint16_t padding;
 	uint32_t location;
-} __attribute__((__packed__));
+});
 
 #ifdef __cplusplus
 }

--- a/src/usbmuxd-proto.h
+++ b/src/usbmuxd-proto.h
@@ -4,6 +4,7 @@
  * Copyright (C) 2009 Paul Sladen <libiphone@paul.sladen.org>
  * Copyright (C) 2009 Nikias Bassen <nikias@gmx.li>
  * Copyright (C) 2009 Hector Martin <hector@marcansoft.com>
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/src/utils.c
+++ b/src/utils.c
@@ -36,6 +36,7 @@
 #endif
 
 #ifdef WIN32
+#include <WinSock2.h>
 #include <windows.h>
 #include "winsock2-ext.h"
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,7 @@
  *
  * Copyright (C) 2009 Hector Martin <hector@marcansoft.com>
  * Copyright (C) 2009 Nikias Bassen <nikias@gmx.li>
+ * Copyright (C) 2014 Frederik Carlier <frederik.carlier@quamotion.mobi>
  *
  * This library is free software; you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as
@@ -22,7 +23,11 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#ifdef WIN32
+#else
 #include <poll.h>
+#endif
+
 #include <plist/plist.h>
 
 enum fdowner {

--- a/src/winsock2-ext.h
+++ b/src/winsock2-ext.h
@@ -1,0 +1,12 @@
+#define nfds_t ULONG
+
+#define POLLRDNORM 0x0100
+#define POLLRDBAND 0x0200
+#define POLLIN    (POLLRDNORM | POLLRDBAND)
+
+#define POLLWRNORM 0x0010
+#define POLLOUT (POLLWRNORM)
+
+/* Mapping of BSD names to Windows names */
+#define EWOULDBLOCK WSAEWOULDBLOCK
+#define sockaddr_un sockaddr_in

--- a/src/winsock2-ext.h
+++ b/src/winsock2-ext.h
@@ -1,3 +1,22 @@
+/*
+ * winsock2-ext.h
+ *
+ * Copyright (C) 2016 Frederik Carlier <frederik.carlier@quamotion.mobi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 or version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 #define nfds_t ULONG
 
 #define POLLRDNORM 0x0100


### PR DESCRIPTION
This PR adds support for usbmuxd on Windows.

In short, the following changes were required:
- Compatibility with winsock2 for sockets
- The "set configuration" command is not implemented by libusb on Windows, but it is supported by libusb-win32 (if you also use the libusb-win32 driver). So libusb-win32 is used on Windows to set the configuraton
- The polling sockets for usb devices are not available on libusb on Windows
- Some fixes to make the code play nice with the Visual C++ compiler

As always, feedback is welcome.
