### PR TITLE
Enable cross-compiling for ARM

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -108,9 +108,7 @@ AC_TYPE_UINT8_T
 AC_SEARCH_LIBS([clock_gettime],[rt posix4])
 
 # Checks for library functions.
-AC_FUNC_MALLOC
-AC_FUNC_REALLOC
-AC_CHECK_FUNCS([strcasecmp strdup strerror strndup stpcpy])
+AC_CHECK_FUNCS([strcasecmp strdup strerror strndup stpcpy malloc realloc])
 AC_CHECK_FUNCS([ppoll clock_gettime localtime_r])
 
 # Check for operating system


### PR DESCRIPTION
When cross-compiling for ARM, `AC_FUNC_MALLOC` would resolve to rpl_malloc
which is undefined. The simplest fix seems to be to remove `AC_FUNC_MALLOC`
and `AC_FUNC_REALLOC`, and replace them with checks in `AC_CHECK_FUNC`
