### PR TITLE
allow preflight error to pass so simple mode will still work

### DIFF
--- a/src/preflight.c
+++ b/src/preflight.c
@@ -232,7 +232,9 @@ retry:
 		lockdownd_service_descriptor_t service = NULL;
 		lerr = lockdownd_start_service(lockdown, "com.apple.mobile.insecure_notification_proxy", &service);
 		if (lerr != LOCKDOWN_E_SUCCESS) {
-			usbmuxd_log(LL_ERROR, "%s: ERROR: Could not start insecure_notification_proxy on %s, lockdown error %d", __func__, _dev->udid, lerr);
+			/* even though we failed, simple mode should still work, so only warn of an error */
+			usbmuxd_log(LL_INFO, "%s: ERROR: Could not start insecure_notification_proxy on %s, lockdown error %d", __func__, _dev->udid, lerr);
+			client_device_add(info);
 			goto leave;
 		}
 


### PR DESCRIPTION
This is almost certainly the wrong way to do this but since I don't have the in-depth knowledge of this software and/or protocol I'm hoping this works well enough for someone to pick it up and do it "right". Background is a disabled 9.3.2 device was failing with error -17 at this point. The patch allows it to fail at client level instead, but still works in simple mode for identification purposes.