### PR TITLE
Better error handling when saving pair records

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -214,7 +214,7 @@ char *string_concat(const char *str, ...)
 	return result;
 }
 
-void buffer_read_from_filename(const char *filename, char **buffer, uint64_t *length)
+int buffer_read_from_filename(const char *filename, char **buffer, uint64_t *length)
 {
 	FILE *f;
 	uint64_t size;
@@ -223,7 +223,7 @@ void buffer_read_from_filename(const char *filename, char **buffer, uint64_t *le
 
 	f = fopen(filename, "rb");
 	if (!f) {
-		return;
+		return 0;
 	}
 
 	fseek(f, 0, SEEK_END);
@@ -232,26 +232,49 @@ void buffer_read_from_filename(const char *filename, char **buffer, uint64_t *le
 
 	if (size == 0) {
 		fclose(f);
-		return;
+		return 0;
 	}
 
 	*buffer = (char*)malloc(sizeof(char)*(size+1));
+
+	if (!buffer) {
+		return 0;
+	}
+
+	int ret = 1;
 	if (fread(*buffer, sizeof(char), size, f) != size) {
 		usbmuxd_log(LL_ERROR, "%s: ERROR: couldn't read %d bytes from %s", __func__, (int)size, filename);
+		free(buffer);
+		ret = 0;
+		errno = EIO;
 	}
 	fclose(f);
 
 	*length = size;
+	return ret;
 }
 
-void buffer_write_to_filename(const char *filename, const char *buffer, uint64_t length)
+int buffer_write_to_filename(const char *filename, const char *buffer, uint64_t length)
 {
 	FILE *f;
 
 	f = fopen(filename, "wb");
 	if (f) {
-		fwrite(buffer, sizeof(char), length, f);
+		int written = fwrite(buffer, sizeof(char), length, f);
 		fclose(f);
+
+		if (written == length) {
+			return 1;
+		}
+		else {
+			// Not all data could be written.
+			errno = EIO;
+			return 0;
+		}
+	}
+	else {
+		// Failed to open the file, let the caller know.
+		return 0;
 	}
 }
 
@@ -263,9 +286,7 @@ int plist_read_from_filename(plist_t *plist, const char *filename)
 	if (!filename)
 		return 0;
 
-	buffer_read_from_filename(filename, &buffer, &length);
-
-	if (!buffer) {
+	if (!buffer_read_from_filename(filename, &buffer, &length)) {
 		return 0;
 	}
 
@@ -295,11 +316,11 @@ int plist_write_to_filename(plist_t plist, const char *filename, enum plist_form
 	else
 		return 0;
 
-	buffer_write_to_filename(filename, buffer, length);
+	int res  = buffer_write_to_filename(filename, buffer, length);
 
 	free(buffer);
 
-	return 1;
+	return res;
 }
 
 #ifdef __APPLE__

--- a/src/utils.h
+++ b/src/utils.h
@@ -75,8 +75,8 @@ char *stpcpy(char * s1, const char * s2);
 #endif
 char *string_concat(const char *str, ...);
 
-void buffer_read_from_filename(const char *filename, char **buffer, uint64_t *length);
-void buffer_write_to_filename(const char *filename, const char *buffer, uint64_t length);
+int buffer_read_from_filename(const char *filename, char **buffer, uint64_t *length);
+int buffer_write_to_filename(const char *filename, const char *buffer, uint64_t length);
 
 enum plist_format_t {
 	PLIST_FORMAT_XML,


### PR DESCRIPTION
`plist_write_to_filename` and `buffer_write_to_filename` now return 0 if the actual write operation failed (e.g. because access is denied to the file), and set `errno` if required.

As a result, an error message is now output to the console when saving the pair record fails.