### PR TITLE
Send a pairing notification once a device has paired with the computer.

### DIFF
--- a/src/client.h
+++ b/src/client.h
@@ -35,6 +35,7 @@ int client_notify_connect(struct mux_client *client, enum usbmuxd_result result)
 
 void client_device_add(struct device_info *dev);
 void client_device_remove(int device_id);
+void client_device_paired(int device_id);
 
 int client_accept(int fd);
 void client_get_fds(struct fdlist *list);

--- a/src/preflight.c
+++ b/src/preflight.c
@@ -107,6 +107,9 @@ static void np_callback(const char* notification, void* userdata)
 		lockdownd_client_free(lockdown);
 		// device will reconnect by itself at this point.
 
+		// Let the clients know the device has paired successfully.
+		client_device_paired((int)(long)_dev->conn_data);
+
 	} else if (strcmp(notification, "com.apple.mobile.lockdown.request_host_buid") == 0) {
 		lerr = lockdownd_client_new(cbdata->dev, &lockdown, "usbmuxd");
 		if (lerr != LOCKDOWN_E_SUCCESS) {

--- a/src/usbmuxd-proto.h
+++ b/src/usbmuxd-proto.h
@@ -52,7 +52,7 @@ enum usbmuxd_msgtype {
 	MESSAGE_LISTEN = 3,
 	MESSAGE_DEVICE_ADD = 4,
 	MESSAGE_DEVICE_REMOVE = 5,
-	//???
+	MESSAGE_DEVICE_PAIRED = 6,
 	//???
 	MESSAGE_PLIST = 8,
 };


### PR DESCRIPTION
Support for `IDEVICE_DEVICE_PAIRED` has been recently added to libimobiledevice by @zbalaton (https://github.com/libimobiledevice/libimobiledevice/commit/4bdea2983a3204332b09408c62e440a0b8e23605), this implements the usbmuxd-side of the contract.