### PR TITLE
Removing build error 

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -302,11 +302,8 @@ int plist_write_to_filename(plist_t plist, const char *filename, enum plist_form
 	return 1;
 }
 
-#ifdef __APPLE__
-typedef int clockid_t;
-#define CLOCK_MONOTONIC 1
 
-static int clock_gettime(clockid_t clk_id, struct timespec *ts)
+int clock_gettime(clockid_t clk_id, struct timespec *ts)
 {
 	// See http://developer.apple.com/library/mac/qa/qa1398
 
@@ -330,7 +327,6 @@ static int clock_gettime(clockid_t clk_id, struct timespec *ts)
 
 	return 0;
 }
-#endif
 
 void get_tick_count(struct timeval * tv)
 {


### PR DESCRIPTION
```
utils.c:306:13: error: typedef redefinition with different types ('int' vs 'enum clockid_t')
typedef int clockid_t;
            ^
/usr/include/time.h:171:3: note: previous definition is here
} clockid_t;
  ^
utils.c:307:9: warning: 'CLOCK_MONOTONIC' macro redefined [-Wmacro-redefined]
#define CLOCK_MONOTONIC 1
        ^
/usr/include/time.h:156:9: note: previous definition is here
#define CLOCK_MONOTONIC _CLOCK_MONOTONIC
        ^
utils.c:309:12: error: static declaration of 'clock_gettime' follows non-static declaration
static int clock_gettime(clockid_t clk_id, struct timespec *ts)
           ^
/usr/include/time.h:177:5: note: previous declaration is here
int clock_gettime(clockid_t __clock_id, struct timespec *__tp);
    ^
1 warning and 2 errors generated.
```