### PR TITLE
client: Plug memory leak

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -617,6 +617,7 @@ static int client_command(struct mux_client *client, struct usbmuxd_header *hdr)
 					} else {
 						rval = EINVAL;
 					}
+					free(record_data);
 					if (send_result(client, hdr->tag, rval) < 0)
 						return -1;
 					return 0;


### PR DESCRIPTION
==14167== 6,708 bytes in 1 blocks are definitely lost in loss record 4 of 4
==14167==    at 0x4C2BC36: malloc (vg_replace_malloc.c:299)
==14167==    by 0x528438F: plist_get_type_and_value (plist.c:711)
==14167==    by 0x5285A32: plist_get_data_val (plist.c:795)
==14167==    by 0x4059F1: client_command (client.c:607)
==14167==    by 0x4059F1: process_recv (client.c:755)
==14167==    by 0x4059F1: client_process (client.c:781)
==14167==    by 0x4042BA: main_loop (main.c:246)
==14167==    by 0x4042BA: main (main.c:697)