### PR TITLE
build: check if clock_gettime() requires -lrt on old GNU systems

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,6 +92,9 @@ AC_TYPE_UINT16_T
 AC_TYPE_UINT32_T
 AC_TYPE_UINT8_T
 
+# Check if clock_gettime requires -lrt (old GNU systems)
+AC_SEARCH_LIBS([clock_gettime],[rt posix4])
+
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC


### PR DESCRIPTION
Ensures HAVE_CLOCK_GETTIME is set on systems with glibc < 2.17 (Ubuntu 12.04 uses 2.15).

Fixes #98 