### PR TITLE
Define both _BSD_SOURCE and _DEFAULT_SOURCE for CentOS 7 support

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -19,6 +19,7 @@
  */
 
 #define _DEFAULT_SOURCE
+#define _BSD_SOURCE
 
 #ifdef HAVE_CONFIG_H
 #include <config.h>


### PR DESCRIPTION
c3fc55697b8fdf59055e4842a9e6bf7db15a35c9 replaced  `_BSD_SOURCE` with `_DEFAULT_SOURCE`.

`_BSD_SOURCE` was deprecated in glibc 2.20, but some distros such as CentOS 7 ship with an older version of glibc (2.17 in the case of CentOS 7). Compilation of usbmuxd will now fail on these distros.

The [manpage for glibc](http://manpages.ubuntu.com/manpages/bionic/man7/feature_test_macros.7.html) recommends to define both `_BSD_SOURCE` and `_DEFAULT_SOURCE`, so let's do that instead:

```
       _BSD_SOURCE (deprecated since glibc 2.20)
               Defining  this  macro  with  any  value  causes header files to expose BSD-derived
               definitions.

               In glibc versions up to and including 2.18, defining this macro  also  causes  BSD
               definitions  to  be  preferred in some situations where standards conflict, unless
               one  or  more  of  _SVID_SOURCE,  _POSIX_SOURCE,  _POSIX_C_SOURCE,  _XOPEN_SOURCE,
               _XOPEN_SOURCE_EXTENDED,  or  _GNU_SOURCE is defined, in which case BSD definitions
               are disfavored.  Since glibc 2.19, _BSD_SOURCE no longer causes BSD definitions to
               be preferred in case of conflicts.

               Since  glibc  2.20,  this  macro  is  deprecated.   It  now has the same effect as
               defining  _DEFAULT_SOURCE,  but   generates   a   compile-time   warning   (unless
               _DEFAULT_SOURCE  is  also  defined).   Use _DEFAULT_SOURCE instead.  To allow code
               that requires _BSD_SOURCE in glibc 2.19 and earlier and _DEFAULT_SOURCE  in  glibc
               2.20   and  later  to  compile  without  warnings,  define  both  _BSD_SOURCE  and
               _DEFAULT_SOURCE.
```