### PR TITLE
No preflight (always for T2)

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -690,7 +690,7 @@ static void device_tcp_input(struct mux_device *dev, struct tcphdr *th, unsigned
 				return;
 			}
 			conn->state = CONN_CONNECTED;
-			usbmuxd_log(LL_DEBUG, "Client connected to device %d (%d->%d)", dev->id, sport, dport);
+			usbmuxd_log(LL_INFO, "Client connected to device %d (%d->%d)", dev->id, sport, dport);
 			if(client_notify_connect(conn->client, RESULT_OK) < 0) {
 				conn->client = NULL;
 				connection_teardown(conn);

--- a/src/device.c
+++ b/src/device.c
@@ -224,7 +224,7 @@ static int send_packet(struct mux_device *dev, enum mux_protocol proto, void *he
 		mhdr->tx_seq = htons(dev->tx_seq);
 		mhdr->rx_seq = htons(dev->rx_seq);
 		dev->tx_seq++;
-	}	
+	}
 	memcpy(buffer + mux_header_size, header, hdrlen);
 	if(data && length)
 		memcpy(buffer + mux_header_size + hdrlen, data, length);
@@ -690,6 +690,7 @@ static void device_tcp_input(struct mux_device *dev, struct tcphdr *th, unsigned
 				return;
 			}
 			conn->state = CONN_CONNECTED;
+			usbmuxd_log(LL_DEBUG, "Client connected to device %d (%d->%d)", dev->id, sport, dport);
 			if(client_notify_connect(conn->client, RESULT_OK) < 0) {
 				conn->client = NULL;
 				connection_teardown(conn);
@@ -978,8 +979,8 @@ void device_check_timeouts(void)
 	FOREACH(struct mux_device *dev, &device_list) {
 		if(dev->state == MUXDEV_ACTIVE) {
 			FOREACH(struct mux_connection *conn, &dev->connections) {
-				if((conn->state == CONN_CONNECTED) && 
-						(conn->flags & CONN_ACK_PENDING) && 
+				if((conn->state == CONN_CONNECTED) &&
+						(conn->flags & CONN_ACK_PENDING) &&
 						(ct - conn->last_ack_time) > ACK_TIMEOUT) {
 					usbmuxd_log(LL_DEBUG, "Sending ACK due to expired timeout (%" PRIu64 " -> %" PRIu64 ")", conn->last_ack_time, ct);
 					send_tcp_ack(conn);

--- a/src/preflight.c
+++ b/src/preflight.c
@@ -41,6 +41,9 @@
 #include "client.h"
 #include "conf.h"
 #include "log.h"
+#include "usb.h"
+
+extern int no_preflight;
 
 #ifdef HAVE_LIBIMOBILEDEVICE
 #ifndef HAVE_ENUM_IDEVICE_CONNECTION_TYPE
@@ -270,7 +273,7 @@ retry:
 			"com.apple.mobile.lockdown.request_pair",
 			"com.apple.mobile.lockdown.request_host_buid",
 			NULL
-		}; 
+		};
 		np_observe_notifications(np, spec);
 
 		/* TODO send notification to user's desktop */
@@ -353,6 +356,11 @@ void preflight_device_remove_cb(void *data)
 
 void preflight_worker_device_add(struct device_info* info)
 {
+	if (info->pid == PID_APPLE_T2_COPROCESSOR || no_preflight == 1) {
+		client_device_add(info);
+		return;
+	}
+
 #ifdef HAVE_LIBIMOBILEDEVICE
 	struct device_info *infocopy = (struct device_info*)malloc(sizeof(struct device_info));
 


### PR DESCRIPTION
Adds new `--no-preflight` option to prevent access to lockdownd

Since this doesn't exist on the T2, it never preflights the T2