### PR TITLE
Move PIDFile to /run

### DIFF
--- a/systemd/usbmuxd.service.in
+++ b/systemd/usbmuxd.service.in
@@ -4,4 +4,4 @@ Documentation=man:usbmuxd(8)
 
 [Service]
 ExecStart=@sbindir@/usbmuxd --user usbmux --systemd
-PIDFile=@localstatedir@/run/usbmuxd.pid
+PIDFile=/run/usbmuxd.pid


### PR DESCRIPTION
systemd on Fedora complains:
```
/usr/lib/systemd/system/usbmuxd.service:7: PIDFile= references a path below legacy directory /var/run/, updating /var/run/usbmuxd.pid → /run/usbmuxd.pid; please update the unit file accordingly.
```