### PR TITLE
docs: fix simple typo, defintion -> definition

### DIFF
--- a/src/usbmuxd-proto.h
+++ b/src/usbmuxd-proto.h
@@ -19,7 +19,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-/* Protocol defintion for usbmuxd proxy protocol */
+/* Protocol definition for usbmuxd proxy protocol */
 #ifndef USBMUXD_PROTO_H
 #define USBMUXD_PROTO_H
 


### PR DESCRIPTION
There is a small typo in src/usbmuxd-proto.h.

Should read `definition` rather than `defintion`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md