### PR TITLE
Enabling binding on a TCP port instead of a Unix socket

### DIFF
--- a/src/usbmuxd-proto.h
+++ b/src/usbmuxd-proto.h
@@ -26,9 +26,8 @@
 #include <stdint.h>
 #define USBMUXD_PROTOCOL_VERSION 0
 
-#if defined(WIN32) || defined(__CYGWIN__)
 #define USBMUXD_SOCKET_PORT 27015
-#else
+#if !defined(WIN32) && !defined(__CYGWIN__)
 #define USBMUXD_SOCKET_FILE "/var/run/usbmuxd"
 #endif
 


### PR DESCRIPTION
This PR adds the `-t`  option to usbmuxd, causing it to bind to `127.0.0.1:27015` instead of `/var/run/usbmuxd`, and the `-a`  option, causing it to bind to `0:0:0:0:27015`.

This can be useful in a couple of scenarios, for example when usbmuxd is running in a container in a Kubernetes cluster, and you want to have other services connect to it.

(Alternatively, you could spin up a side-container which just runs socat)