### PR TITLE
Allow configuration number 5

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -394,8 +394,8 @@ static int usb_device_add(libusb_device* dev)
 	}
 
 	int desired_config = devdesc.bNumConfigurations;
-	if (desired_config > 4) {
-		desired_config = 4;
+	if (desired_config > 5) {
+		desired_config = 5;
 	}
 	int current_config = 0;
 	if((res = libusb_get_configuration(handle, &current_config)) != 0) {


### PR DESCRIPTION
Newer iOS devices can expose a video feed which contains a mirror of their main display over USB.

You need to send a specially-crafted setup packet to the device, after which it will expose a 5th configuration with a new interface - see https://github.com/danielpaulus/quicktime_video_hack for some open source details.
By default, usbmuxd will reject this configuration and connect to the 4th configuration.

I think it makes sense to usbmuxd to enable the 5th configuration if it is available.
You can only end up with this configuration if you've sent that setup packet to the device, so it's very likely intentional.

This reverts 1f8ddeff95884da404a7fbd74d27e04ca8c99a50 / #91 which cites VMware, however, I've validated this scenario on VMware (Ubuntu guest on a Windows host).