### PR TITLE
Don't call libusb_set_option if libusb_init fails

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -827,16 +827,16 @@ int usb_init(void)
 	device_polling = 1;
 	res = libusb_init(NULL);
 
+	if (res != 0) {
+		usbmuxd_log(LL_FATAL, "libusb_init failed: %s", libusb_error_name(res));
+		return -1;
+	}
+
 #if LIBUSB_API_VERSION >= 0x01000106
 	libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, (log_level >= LL_DEBUG ? LIBUSB_LOG_LEVEL_DEBUG: (log_level >= LL_WARNING ? LIBUSB_LOG_LEVEL_WARNING: LIBUSB_LOG_LEVEL_NONE)));
 #else
 	libusb_set_debug(NULL, (log_level >= LL_DEBUG ? LIBUSB_LOG_LEVEL_DEBUG: (log_level >= LL_WARNING ? LIBUSB_LOG_LEVEL_WARNING: LIBUSB_LOG_LEVEL_NONE)));
 #endif
-
-	if(res != 0) {
-		usbmuxd_log(LL_FATAL, "libusb_init failed: %s", libusb_error_name(res));
-		return -1;
-	}
 
 	collection_init(&device_list);
 


### PR DESCRIPTION
Calling into `libusb_set_option` when `libusb_init` fails will result in a segmentation fault.
This PR updates the code to immediately exit when `libusb_init` returns an error code and don't attempt to set the log level.

One way to make `libusb_init` fail is to run `usbmuxd` on a VM with no USB stack/no usbfs (e.g. the VMs in GitHub actions don't have an USB stack, that's how I found out).

To enable libusb debug output in `libusb_init`, set the `LIBUSB_DEBUG` environment.

This fixes a regression introduced in 6bbe87b6f6c5ef388839ebf64a7d38fcd91468bf.
