### PR TITLE
log: print filename and line number

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -61,7 +61,7 @@ static int level_to_syslog_level(int level)
 	return result;
 }
 
-void usbmuxd_log(enum loglevel level, const char *fmt, ...)
+void usbmuxd_logx(enum loglevel level, const char *fmt, ...)
 {
 	va_list ap;
 	char *fs;

--- a/src/log.h
+++ b/src/log.h
@@ -37,6 +37,8 @@ extern unsigned int log_level;
 void log_enable_syslog();
 void log_disable_syslog();
 
-void usbmuxd_log(enum loglevel level, const char *fmt, ...) __attribute__ ((format (printf, 2, 3)));
+void usbmuxd_logx(enum loglevel level, const char* fmt, ...) __attribute__ ((format (printf, 2, 3)));
+#define usbmuxd_log(level, fmt, ...) \
+	usbmuxd_logx(level, "%s:%d " fmt , __FILE__, __LINE__, ##__VA_ARGS__)
 
 #endif


### PR DESCRIPTION
add more information when logging, like this

```
[20:55:03.616][3] main.c:719 enabling libimobiledevice logging
[20:55:03.616][3] main.c:730 usbmuxd v1.1.2 starting up
[20:55:03.616][4] main.c:838 Creating socket
[20:55:03.616][4] main.c:196 Preparing a Unix socket
[20:55:03.616][4] main.c:202 Binding to socket
[20:55:03.616][4] main.c:223 Starting to listen on socket
[20:55:03.616][4] main.c:933 Initializing USB
[20:55:03.616][3] usb.c:852 Using libusb 1.0.21
[20:55:03.618][4] usb.c:877 Registering for libusb hotplug events
[20:55:03.618][4] usb.c:418 Found new device with v/p 05ac:12a8 at 1-14
[20:55:03.618][4] usb.c:514 Found interface 1 with endpoints 04/85 for device 1-14
[20:55:03.618][4] usb.c:574 Using wMaxPacketSize=512 for device 1-14
[20:55:03.618][4] usb.c:594 USB Speed is 480 MBit/s for device 1-14
[20:55:03.618][4] main.c:938 1 device detected
[20:55:03.618][3] main.c:940 Initialization complete
[20:55:03.618][4] client.c:261 Client 12 accepted: /usr/lib/gvfs/gvfs-afc-volume-monitor[4254]
```
