### PR TITLE
Add Apple Silicon restore support

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -381,7 +381,8 @@ static int usb_device_add(libusb_device* dev)
 	if(devdesc.idVendor != VID_APPLE)
 		return -1;
 	if((devdesc.idProduct != PID_APPLE_T2_COPROCESSOR) &&
-		((devdesc.idProduct < PID_RANGE_LOW) ||
+	   (devdesc.idProduct != PID_APPLE_SILICON_RESTORE) &&
+	   ((devdesc.idProduct < PID_RANGE_LOW) ||
 		(devdesc.idProduct > PID_RANGE_MAX)))
 		return -1;
 	libusb_device_handle *handle;

--- a/src/usb.h
+++ b/src/usb.h
@@ -47,6 +47,7 @@
 #define PID_RANGE_LOW 0x1290
 #define PID_RANGE_MAX 0x12af
 #define PID_APPLE_T2_COPROCESSOR 0x8600
+#define PID_APPLE_SILICON_RESTORE 0x1901
 
 struct usb_device;
 

--- a/udev/39-usbmuxd.rules.in
+++ b/udev/39-usbmuxd.rules.in
@@ -1,13 +1,13 @@
 # usbmuxd (Apple Mobile Device Muxer listening on /var/run/usbmuxd)
 
 # systemd should receive all events relating to device
-SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="5ac/12[9a][0-9a-f]/*|5ac/8600/*", TAG+="systemd"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="5ac/12[9a][0-9a-f]/*|5ac/1901/*|5ac/8600/*", TAG+="systemd"
 
 # Initialize iOS devices into "deactivated" USB configuration state and activate usbmuxd
-SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="5ac/12[9a][0-9a-f]/*|5ac/8600/*", ACTION=="add", ENV{USBMUX_SUPPORTED}="1", ATTR{bConfigurationValue}="0", OWNER="usbmux", @udev_activation_rule@
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="5ac/12[9a][0-9a-f]/*|5ac/1901/*|5ac/8600/*", ACTION=="add", ENV{USBMUX_SUPPORTED}="1", ATTR{bConfigurationValue}="0", OWNER="usbmux", @udev_activation_rule@
 
 # Make sure properties don't get lost when bind action is called
-SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="5ac/12[9a][0-9a-f]/*|5ac/8600/*", ACTION=="bind", ENV{USBMUX_SUPPORTED}="1", OWNER="usbmux", @udev_activation_rule@
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="5ac/12[9a][0-9a-f]/*|5ac/1901/*|5ac/8600/*", ACTION=="bind", ENV{USBMUX_SUPPORTED}="1", OWNER="usbmux", @udev_activation_rule@
 
 # Exit usbmuxd when the last device is removed
-SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="5ac/12[9a][0-9a-f]/*|5ac/8600/*", ACTION=="remove", RUN+="@sbindir@/usbmuxd -x"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ENV{PRODUCT}=="5ac/12[9a][0-9a-f]/*|5ac/1901/*|5ac/8600/*", ACTION=="remove", RUN+="@sbindir@/usbmuxd -x"


### PR DESCRIPTION
Hello !

The M1 mac mini presents itself with PID 0x1901 when in restore mode. 

This MR adds support for it in:
- The udev rules
- `usb.c` for usbmuxd to recognize it when triggered

If you don't like the constant name, i'd be happy to change it. Couldn't find anything better :/