### PR TITLE
Add install instructions for OS X on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ To output a list of available configure options use:
 ./autogen.sh --help
 ```
 
+### OS X
+
+There are two ways:
+
+#### Using Macports
+
+```
+sudo port install libimobiledevice
+```
+
+#### Using Home Brew
+
+```
+brew install libimobiledevice
+```
+
+
 ## Usage
 
 The daemon is automatically started by udev or systemd depending on what you


### PR DESCRIPTION
I've missed the installation instruction for OS X, so I'm sending this PR.