### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,18 @@ To output a list of available configure options use:
 ./autogen.sh --help
 ```
 
+Alternatively, you can build and install usbmuxd using [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager:
+
+```bash or powershell
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.sh # "./bootstrap-vcpkg.bat" for powershell
+./vcpkg integrate install
+./vcpkg install usbmuxd
+```
+
+The usbmuxd port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Usage
 
 The daemon is automatically started by udev or systemd depending on what you


### PR DESCRIPTION
`usbmuxd` is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `usbmuxd` and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `usbmuxd`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/usbmuxd/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)