### PR TITLE
systemd: use runstatedir

### DIFF
--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -1,7 +1,7 @@
 edit = \
 	$(SED) -r \
 	-e 's|@sbindir[@]|$(sbindir)|g' \
-	-e 's|@localstatedir[@]|$(localstatedir)|g' \
+	-e 's|@runstatedir[@]|$(runstatedir)|g' \
 	< $< > $@ || rm $@
 
 if WANT_SYSTEMD

--- a/systemd/usbmuxd.service.in
+++ b/systemd/usbmuxd.service.in
@@ -4,4 +4,4 @@ Documentation=man:usbmuxd(8)
 
 [Service]
 ExecStart=@sbindir@/usbmuxd --user usbmux --systemd
-PIDFile=@localstatedir@/run/usbmuxd.pid
+PIDFile=@runstatedir@/usbmuxd.pid


### PR DESCRIPTION
On newer versions of systemd, there is an expectation that `/run` is
used instead of `/var/run`.  The current service file template can
result in the following error message in the service:

```
systemd[1]: /lib/systemd/system/usbmuxd.service:7: PIDFile= references a path below legacy directory /var/run/, updating /var/run/usbmuxd.pid → /run/usbmuxd.pid; please update the unit file accordingly.
```

Prefer the `@runstatedir@` over `@localstatedir/run@` pattern as
suggested by [1].

[1]: https://www.gnu.org/prep/standards/html_node/Directory-Variables.html

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
