### PR TITLE
Fixes segfaults in get_mode_cb

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -683,8 +683,8 @@ static void get_mode_cb(struct libusb_transfer* transfer)
 	if(transfer->status != LIBUSB_TRANSFER_COMPLETED) {
 		usbmuxd_log(LL_ERROR, "Failed to request get mode for device %i-%i (%i). Completing initialization in current mode", 
 			context->bus, context->address, transfer->status);
-		free(context);
 		device_complete_initialization(context, transfer->dev_handle);
+		free(context);
 		return;
 	}
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -690,7 +690,8 @@ static void get_mode_cb(struct libusb_transfer* transfer)
 
 	unsigned char *data = libusb_control_transfer_get_data(transfer);
 
-	int desired_mode = atoi(getenv(ENV_DEVICE_MODE));
+	char* desired_mode_char = getenv(ENV_DEVICE_MODE);
+	int desired_mode = desired_mode_char ? atoi(desired_mode_char) : 1;
 	int guessed_mode = guess_mode(context->dev, dev);
 
 	// Response is 3:3:3:0 for initial mode, 5:3:3:0 otherwise.


### PR DESCRIPTION
This pull request has two fixes:
- A use-after-free in the case we failed to request get mode
- A getenv that is not checked in case ENV_DEVICE_MODE is not set