### PR TITLE
Drop --foreground

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -34,6 +34,8 @@ Version 1.1.1
   - Unify and improve log message output
   - Improve README.md with project description, installation, contributing and
     usage sections
+  - The "--foreground" flag has been removed; usbmuxd now runs in foreground by
+    default.
 
 Version 1.1.0
 ~~~~~~~~~~~~~

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ The daemon also manages pairing records with iOS devices and the host in
 
 Ensure proper permissions are setup for the daemon to access the directory.
 
-For debugging purposes it is helpful to start usbmuxd using the foreground `-f`
-argument and enable verbose mode `-v` to get suitable logs.
+For debugging purposes it is helpful to enable verbose mode `-v` to get
+suitable logs.
 
 Please consult the usage information or manual page for a full documentation of
 available command line options:

--- a/docs/usbmuxd.8
+++ b/docs/usbmuxd.8
@@ -32,9 +32,6 @@ Ensure proper permissions are setup for the daemon to access the directory.
 .B \-U, \-\-user USER
 Change to this user after startup (needs USB privileges).
 .TP
-.B \-f, \-\-foreground
-Do not daemonize (implies one -v).
-.TP
 .B \-n, \-\-disable-hotplug
 Disables automatic discovery of devices on hotplug. Starting another instance
 will trigger discovery instead.


### PR DESCRIPTION
Always run in foreground by default. Service manager and supervisors expect services to run in foreground, so they can track the lifetime of the child process. Those that don't implement their own logic to fork daemons anyway.

For users running `usbmuxd` manually, running in background by default provides a confusing experience, since it gives the impression of exiting immediately.

Anyone needing to run `usbmuxd` in background can use a shell's & operator or something like nohop.