### PR TITLE
usb: Revert default mode back to 1

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -691,7 +691,7 @@ static void get_mode_cb(struct libusb_transfer* transfer)
 	unsigned char *data = libusb_control_transfer_get_data(transfer);
 
 	char* desired_mode_char = getenv(ENV_DEVICE_MODE);
-	int desired_mode = desired_mode_char ? atoi(desired_mode_char) : 3;
+	int desired_mode = desired_mode_char ? atoi(desired_mode_char) : 1;
 	int guessed_mode = guess_mode(context->dev, dev);
 
 	// Response is 3:3:3:0 for initial mode, 5:3:3:0 otherwise.


### PR DESCRIPTION
[1] changes to mode 3 CDC NCM by default. Revert back to mode 1: Originally mode 1 was used, where a tethered iPhone appears as an Ethernet interface, handled by the ipheth driver. This has been the default for many years and is known to work on iPhone 3G, 4S, 7 Plus, 11 and newer. Since [2-3] ipheth supports CDC NCM in mode 1, and configures the iPhone to use it.

In mode 3, the Ethernet interface is handled by kmod-usb-net-cdc-ncm. This driver has better performance, but now the iPhone does not provide DHCP or Internet connectivity, so we should revert to mode 1.

Analysing the network traffic, shows that both the iPhone and OpenWRT are DHCP clients. The iPhone does not act as a DHCP server. I can set a static IP on OpenWRT and lease 172.20.10.1 to the iPhone. Then I can ping the iPhone and I have IPv4 connectivity. However the iPhone does not provide Internet connectivity to OpenWRT. Maybe in mode 3, the iPhone is a client meant to receive Internet over USB and therefore it is not a gateway?

Attempts to switch old iPhones, such as 3G and 4S to mode 3 fail. They remain in mode 1 and work correctly using the ipheth driver.

Comparison, tested on iPhone 7 Plus and 11
- mode 1 eth0 kmod-usb-net-ipheth  264 Mbit/s DHCP server, Internet
- mode 3 usb0 kmod-usb-net-cdc-ncm 304 Mbit/s DHCP client, no Internet

[1] https://github.com/libimobiledevice/usbmuxd/commit/c7a0dd9b82633ea347497626282e3051a469ef50
[2] https://github.com/torvalds/linux/commit/a2d274c62e44b1995c170595db3865c6fe701226
[3] https://github.com/openwrt/openwrt/commit/680f8738d02a1876ae4cd11aacf9cd56e520fadf

@nikias @FunkyM @BalkanMadman @rickmark @Blefish @marcan