### PR TITLE
configure.ac: Do not use '+=' to set CFLAGS to be POSIX-compliant

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -40,7 +40,7 @@ if test "x$have_limd" = "xyes"; then
     AC_SUBST(libimobiledevice_CFLAGS)
     AC_SUBST(libimobiledevice_LIBS)
     CACHED_CFLAGS="$CFLAGS"
-    CFLAGS+=" $libimobiledevice_CFLAGS"
+    CFLAGS="$CFLAGS $libimobiledevice_CFLAGS"
     AC_CACHE_CHECK(for enum idevice_connection_type, ac_cv_enum_idevice_connection_type,
       AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
         #include <libimobiledevice/libimobiledevice.h>


### PR DESCRIPTION
The '+=' operator used in configure.ac to append to the CFLAGS variable is present in Bash, but not the POSIX sh specification. Therefore, the aforementioned part of the configure.ac (from which the configure script is obtained) might not run correctly under non Bash-like POSIX compliant shells (dash - default shell on Debian, ash, etc).

Bug: https://bugs.gentoo.org/924200