### PR TITLE
configure.ac: Do not automatically add '-g' to CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,7 +153,7 @@ AM_CONDITIONAL(WIN32, test x$win32 = xtrue)
 AC_SUBST([UDEV_SUB])
 AC_SUBST([SYSTEMD_SUB])
 
-AS_COMPILER_FLAGS(GLOBAL_CFLAGS, "-g -Wall -Wextra -Wmissing-declarations -Wredundant-decls -Wshadow -Wpointer-arith  -Wwrite-strings -Wswitch-default -Wno-unused-parameter")
+AS_COMPILER_FLAGS(GLOBAL_CFLAGS, "-Wall -Wextra -Wmissing-declarations -Wredundant-decls -Wshadow -Wpointer-arith  -Wwrite-strings -Wswitch-default -Wno-unused-parameter")
 AC_SUBST(GLOBAL_CFLAGS)
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])


### PR DESCRIPTION
The '-g' option enables building the target with debugging information. In the current state, the '-g' option is added automatically with no (easy) way to disable it, apart from patching the configure.ac. This commits removes the '-g' option from th default CFLAGS value, while still allowing for it to be added manually by those who build usbmuxd from source.