### PR TITLE
fix crash during quick connect/disconnet

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -661,7 +661,7 @@ static void device_tcp_input(struct mux_device *dev, struct tcphdr *th, unsigned
 		if(!(th->th_flags & TH_RST)) {
 			usbmuxd_log(LL_INFO, "No connection for device %d incoming packet %d->%d", dev->id, dport, sport);
 			if(send_anon_rst(dev, sport, dport, ntohl(th->th_seq)) < 0)
-				usbmuxd_log(LL_ERROR, "Error sending TCP RST to device %d (%d->%d)", conn->dev->id, sport, dport);
+				usbmuxd_log(LL_ERROR, "Error sending TCP RST to device %d (%d->%d)", dev->id, sport, dport);
 		}
 		return;
 	}


### PR DESCRIPTION
Crash happened while multiple connect/disconnect cycle of the phone.

backtrace of the crash:
```
(gdb) bt
#0  device_tcp_input (payload_length=32728,
    payload=0x1d0abd4 "T\315\bC\211\203m\317t36*{\n\307\366\"\327\v\266;mR\017N\275\362%KN\342ͳQh\211Ny\373!\204\273i\352Q\201\r\r\353\375\270#\033\022\321\310\nB\312\373\320_\321j\272\r\031\202\342\317#Y\226\205i.GC(\"\235_\213ٗS\017#6E\a\023H%\200\f:\363\224n\021o\362l\326\030]\214\377(\333\362\212\036", th=0x1d0abc0, dev=<optimized out>) at device.c:664
#1  device_data_input (usbdev=usbdev@entry=0x1ce2548, buffer=<optimized out>, length=<optimized out>) at device.c:821
#2  0x00017e98 in rx_callback (xfer=0x1ce2b18) at usb.c:211
```