### PR TITLE
usb: Support mode 4 and 5; USB 10 Gbps display

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -394,7 +394,7 @@ static struct usb_device* find_device(int bus, int address)
 /// @param dev 
 /// @param usbdev 
 /// @param handle 
-/// @return 0 - undetermined, 1 - initial, 2 - valeria, 3 - cdc_ncm
+/// @return 0 - undetermined, 1 - initial, 2 - valeria, 3 - cdc_ncm, 4 - usbeth+cdc_ncm, 5 - cdc_ncm direct
 static int guess_mode(struct libusb_device* dev, struct usb_device *usbdev)
 {
 	int res, j;
@@ -404,9 +404,19 @@ static int guess_mode(struct libusb_device* dev, struct usb_device *usbdev)
 	int bus = usbdev->bus;
 	int address = usbdev->address;
 
+	if(devdesc.bNumConfigurations == 1) {
+		// CDC-NCM Direct
+		return 5;
+	}
+
 	if(devdesc.bNumConfigurations <= 4) {
 		// Assume this is initial mode
 		return 1;
+	}
+
+	if(devdesc.bNumConfigurations == 6) {
+		// USB Ethernet + CDC-NCM
+		return 4;
 	}
 
 	if(devdesc.bNumConfigurations != 5) {
@@ -699,7 +709,7 @@ static void get_mode_cb(struct libusb_transfer* transfer)
 
 	// Response is 3:3:3:0 for initial mode, 5:3:3:0 otherwise.
 	usbmuxd_log(LL_INFO, "Received response %i:%i:%i:%i for get_mode request for device %i-%i", data[0], data[1], data[2], data[3], context->bus, context->address);
-	if(desired_mode >= 1 && desired_mode <= 3 && 
+	if(desired_mode >= 1 && desired_mode <= 5 &&
 	   guessed_mode > 0 && // do not switch mode if guess failed
 	   guessed_mode != desired_mode) {
 		usbmuxd_log(LL_WARNING, "Switching device %i-%i mode to %i", context->bus, context->address, desired_mode);

--- a/src/usb.c
+++ b/src/usb.c
@@ -615,6 +615,9 @@ static void device_complete_initialization(struct mode_context *context, struct 
 		case LIBUSB_SPEED_SUPER:
 			usbdev->speed = 5000000000;
 			break;
+		case LIBUSB_SPEED_SUPER_PLUS:
+			usbdev->speed = 10000000000;
+			break;
 		case LIBUSB_SPEED_HIGH:
 		case LIBUSB_SPEED_UNKNOWN:
 		default:


### PR DESCRIPTION
* usb: correctly display 10 Gbps USB 3.x

    iPhone 15 Pro/Pro Max support up to 10 Gbps USB 3.x. Add the necessary case to display the correct link speed.

    Requires libusb 1.0.22 (2018-03-25) or newer, introduced in libusb/libusb@7a91d7cdccaa7dfc3db0828a5230d6260e9338d7

* usb: add support for modes 4 and 5

    * Mode 4
        USB Ethernet + CDC-NCM
        iOS >= 16.0
    * Mode 5
        CDC-NCM Direct only (no usbmux, no USB Ethernet, no PTP)
        iOS >= 17.0