### PR TITLE
conf: fix false plist write error in config_set_device_record

### DIFF
--- a/src/conf.c
+++ b/src/conf.c
@@ -431,7 +431,7 @@ int config_set_device_record(const char *udid, char* record_data, uint64_t recor
 	remove(device_record_file);
 
 	/* store file */
-	if (!plist_write_to_file(plist, device_record_file, PLIST_FORMAT_XML, 0)) {
+	if (plist_write_to_file(plist, device_record_file, PLIST_FORMAT_XML, 0) != PLIST_ERR_SUCCESS) {
 		usbmuxd_log(LL_DEBUG, "Could not open '%s' for writing: %s", device_record_file, strerror(errno));
 		res = -ENOENT;
 	}


### PR DESCRIPTION
Since libplist 2.3.0,`plist_write_to_file` returns 0 if the operation was succeeded, `!plist_write_to_file` only applies if it returns >0. Should change to `!= PLIST_ERR_SUCCESS` or `<0`.😊