### PR TITLE
README: Explain that this `usbmuxd` project is only needed on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ First install all required dependencies and build tools:
 ```shell
 sudo apt-get install \
 	build-essential \
-	xpkg-config \
+	pkg-config \
 	checkinstall \
 	git \
 	autoconf \


### PR DESCRIPTION
Similar to https://github.com/libimobiledevice/libusbmuxd/pull/154.

Closes #263
Closes #232
Closes #184
Closes #126 (probably?)
Closes #247 (probably?)
Closes #255 (probably?)
Closes https://github.com/libimobiledevice/libimobiledevice/issues/1371
(and likely many more)

It is unclear to some users whether `usbmuxd` is referring this project or the service "in general" that is already provided by iTunes on Windows, and as a system service on macOS. They may be trying to build this service and wonder why it is failing to compile for Windows for example (and why there is no CI for Windows, despite mentioning it in the cross-platform list).

Explain more clearly that this is only needed on Linux, at least for now. In the near future it might be advantageous to port this library to provide an implementation for Windows as well, to drop the dependency on iTunes (especially on architectures where it's not natively provided): https://github.com/libimobiledevice/libusbmuxd/issues/153 / https://github.com/libimobiledevice/usbmuxd/issues/263#issuecomment-2980120799 / https://github.com/libimobiledevice/usbmuxd/issues/93.