### PR TITLE
usb: check if the device is alive before remove the device

### DIFF
--- a/src/usb.c
+++ b/src/usb.c
@@ -1022,8 +1022,9 @@ static int usb_hotplug_cb(libusb_context *ctx, libusb_device *device, libusb_hot
 		uint8_t address = libusb_get_device_address(device);
 		FOREACH(struct usb_device *usbdev, &device_list) {
 			if(usbdev->bus == bus && usbdev->address == address) {
+				if (usbdev->alive)
+					device_remove(usbdev);
 				usbdev->alive = 0;
-				device_remove(usbdev);
 				break;
 			}
 		} ENDFOREACH


### PR DESCRIPTION
The device may disconnect and connected (hotplug) before the initialization is finished. When disconnected, the usbmuxd will try to call device_remove in usb.c. However, the device is added to devicelist(in device.c) after initialization. Thus it cannot find the corresponding usb device and unable to remove the device.